### PR TITLE
fix main composite select 'x' null value

### DIFF
--- a/lib/views/MainCompositePicker.js
+++ b/lib/views/MainCompositePicker.js
@@ -65,7 +65,12 @@ export default class MainCompositePicker extends React.Component<Props, State> {
 
 	handleChange = (newValue, actionMeta) => {
 		this.setState({mainComposite: newValue});
-		this.props.handleUpdate(this.state.namespace, newValue.value);
+		if (newValue) {
+			this.props.handleUpdate(this.state.namespace, newValue.value);
+		} else {
+			this.props.handleUpdate("", "");
+		}
+
 	}
 
 	handleInputChange = (inputValue, actionMeta) => {


### PR DESCRIPTION
The select dropdown box for picking a main composite now clears values without throwing an error when clicking the 'x' button in the widget.