### PR TITLE
add commands to open Streaming Analytics console and IBM Cloud dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This is the initial public release.  For best results you should also install th
 
 ### Setup Instructions
 #### Build - Streaming Analytics Credentials
-The <b>build-ibmstreams</b> package requires a running IBM Streaming Analytics service. SPL applications will be built and deployed on this service. If you need to create one, start <a href="https://console.bluemix.net/catalog/services/streaming-analytics" rel="noopener" target="_blank">here</a> and follow the instructions to create an account.
+The <b>build-ibmstreams</b> package requires a running IBM Streaming Analytics service. SPL applications will be built and deployed on this service. If you need to create one, start <a href="https://cloud.ibm.com/catalog/services/streaming-analytics" rel="noopener" target="_blank">here</a> and follow the instructions to create an account.
 
 <b>Note:</b>The service needs to support V2 of the rest api.
 
-Once you have an account go to your <a href="https://console.bluemix.net/dashboard/apps" rel="noopener" target="_blank">dashboard</a> and select the Streaming Analytic service you want to use. You need to make sure it is running and then copy your credentials to the clipboard. To get your credentials select <b>Service Credentials</b> from the actions on the left. From the credentials page, press <b>View credentials</b> for the one you want to use and press the copy button in the upper right side of the credentials to copy them to the clipboard.
+Once you have an account go to your <a href="https://cloud.ibm.com/resources?groups=resource-instance" rel="noopener" target="_blank">dashboard</a> and select the Streaming Analytics service you want to use. You need to make sure it is running and then copy your credentials to the clipboard. To get your credentials select <b>Service Credentials</b> from the actions on the left. From the credentials page, press <b>View credentials</b> for the one you want to use and press the copy button in the upper right side of the credentials to copy them to the clipboard.
 
 In Atom there is a setting in the <b>build-ibmstreams</b> package for the credentials. Go to <b>Atom->Preferences->Packages</b> and press the <b>Settings</b> button on the <b>build-ibmstreams</b> package and paste your credentials into the setting.
 ![](./images/atomcredssetting.png)

--- a/lib/spl-build-common.js
+++ b/lib/spl-build-common.js
@@ -34,6 +34,10 @@ const defaultIgnoreDirectories = [
 	"___bundle"
 ];
 
+const buildConsoleUrl = (url, instanceId) => `${url}#application/dashboard/Application%20Dashboard?instance=${instanceId}`;
+
+const ibmCloudDashboardUrl = "https://cloud.ibm.com/resources";
+
 export class SplBuilder {
 	static BUILD_ACTION = {DOWNLOAD: 0, SUBMIT: 1};
 	static SPL_MSG_REGEX = /^([\w.]+\/[\w.]+)\:(\d+)\:(\d+)\:\s+(\w{5}\d{4}[IWE])\s+((ERROR|WARN|INFO)\:.*)$/;
@@ -257,7 +261,7 @@ export class SplBuilder {
 				map(consoleResult => {
 					const [ artifacts, consoleResponse ] = consoleResult;
 					if (consoleResponse.body["streams_console"] && consoleResponse.body["id"]) {
-						const consoleUrl = `${consoleResponse.body["streams_console"]}#application/dashboard/Application%20Dashboard?instance=${consoleResponse.body["id"]}`;
+						const consoleUrl = buildConsoleUrl(consoleResponse.body["streams_console"], consoleResponse.body["id"]);
 
 						this.submitJobPrompt(consoleUrl, outputDir, this.submitAppObservable.bind(this), artifacts);
 
@@ -307,7 +311,7 @@ export class SplBuilder {
 					map(consoleResult => {
 						const [ submitInput, consoleResponse ] = consoleResult;
 						if (consoleResponse.body["streams_console"] && consoleResponse.body["id"]) {
-							const consoleUrl = `${consoleResponse.body["streams_console"]}#application/dashboard/Application%20Dashboard?instance=${consoleResponse.body["id"]}`;
+							const consoleUrl = buildConsoleUrl(consoleResponse.body["streams_console"], consoleResponse.body["id"]);
 
 							this.submitJobPrompt(consoleUrl, outputDir, this.submitSabObservable.bind(this), input);
 
@@ -518,7 +522,7 @@ export class SplBuilder {
 					{ notificationButtons: [
 						{
 							label: "Open IBM Cloud Dashboard",
-							callbackFn: ()=>{this.openUrlHandler("https://console.bluemix.net/dashboard/apps")}
+							callbackFn: ()=>{this.openUrlHandler(ibmCloudDashboardUrl)}
 						},
 						{
 							label: "Start service and retry",
@@ -580,10 +584,49 @@ export class SplBuilder {
 		});
 	}
 
+	openStreamingAnalyticsConsole(streamingAnalyticsCredentials) {
+		this.serviceCredentials = SplBuilder.parseServiceCredentials(streamingAnalyticsCredentials);
+		if (this.serviceCredentials.apikey && this.serviceCredentials.v2_rest_url) {
+
+			this.getAccessTokenObservable().pipe(
+				mergeMap(response => {
+					this.accessToken = response.body.access_token;
+					return this.getConsoleUrlObservable();
+				}),
+				map(response => {
+					if (response.body["streams_console"] && response.body["id"]) {
+						const consoleUrl = buildConsoleUrl(response.body["streams_console"], response.body["id"]);
+						this.openUrlHandler(consoleUrl);
+					} else {
+						this.messageHandler.handleError("Cannot retrieve Streaming Analytics Console URL");
+					}
+				})
+			).subscribe(
+				next => {},
+				err => {
+        	let errorNotification = null;
+					if (err instanceof Error) {
+						errorNotification = this.messageHandler.handleError(err.name, {detail: err.message, stack: err.stack});
+					} else {
+						errorNotification = this.messageHandler.handleError(err);
+					}
+					this.checkKnownErrors(err);
+				},
+				complete => {
+					console.log("get Console URL observable complete");
+				}
+			);
+		}
+	}
+
+	openCloudDashboard() {
+		this.openUrlHandler(ibmCloudDashboardUrl);
+	}
+
 	getAccessTokenObservable() {
 		const iamTokenRequestOptions = {
 			method: "POST",
-			url: "https://iam.bluemix.net/identity/token",
+			url: "https://iam.cloud.ibm.com/identity/token",
 			json: true,
 			headers: {
 				Accept: "application/json",

--- a/lib/spl-build.js
+++ b/lib/spl-build.js
@@ -62,6 +62,8 @@ export default {
         	"spl-build:build-make-submit": () => this.buildMake(SplBuilder.BUILD_ACTION.SUBMIT),
         	"spl-build:build-make-download": () => this.buildMake(SplBuilder.BUILD_ACTION.DOWNLOAD),
         	"spl-build:submit": () => this.submit(),
+        	"spl-build:open-console": () => this.openConsole(),
+        	"spl-build:open-IBM-cloud-dashboard": () => this.openCloudDashboard()
         }
       )
 		);
@@ -322,6 +324,23 @@ export default {
 
 		this.splBuilder.submit(this.streamingAnalyticsCredentials, {filename: selectedFilePath});
 
+	},
+
+	openConsole() {
+		this.streamingAnalyticsCredentials = atom.config.get(CONF_STREAMING_ANALYTICS_CREDENTIALS);
+		this.consoleService = this.consumeConsoleService({id: name, name: name});
+		this.messageHandler = new MessageHandler(this.consoleService);
+		this.lintHandler = new LintHandler(this.linterService, SplBuilder.SPL_MSG_REGEX, this.appRoot);
+		this.splBuilder = new SplBuilder(this.messageHandler, this.lintHandler, this.openUrlHandler);
+		this.splBuilder.openStreamingAnalyticsConsole(this.streamingAnalyticsCredentials);
+	},
+
+	openCloudDashboard() {
+		this.streamingAnalyticsCredentials = atom.config.get(CONF_STREAMING_ANALYTICS_CREDENTIALS);
+		this.consoleService = this.consumeConsoleService({id: name, name: name});
+		this.messageHandler = new MessageHandler(this.consoleService);
+		this.splBuilder = new SplBuilder(this.messageHandler, null, this.openUrlHandler);
+		this.splBuilder.openCloudDashboard();
 	}
 
 };


### PR DESCRIPTION
Add commands to open Streaming Analytics console and IBM Cloud dashboard. Accessible via Ctrl+Shift+P command palette; "Spl Build: Open Console", and "Spl Build: Open IBM Cloud Dashboard".

Also use the new cloud.ibm.com* URLs instead of bluemix.net.