### PR TITLE
fix Issue #31 and open diagnostics view when compile error occurs

### DIFF
--- a/lib/LintHandler.js
+++ b/lib/LintHandler.js
@@ -67,6 +67,9 @@ export class LintHandler {
 
 			this.linter.setAllMessages(convertedMessages);
 
+			if (Array.isArray(convertedMessages) && convertedMessages.length > 0) {
+				atom.workspace.open("atom://nuclide/diagnostics");
+			}
 		}
 	}
 }

--- a/lib/spl-build-common.js
+++ b/lib/spl-build-common.js
@@ -40,7 +40,7 @@ const ibmCloudDashboardUrl = "https://cloud.ibm.com/resources";
 
 export class SplBuilder {
 	static BUILD_ACTION = {DOWNLOAD: 0, SUBMIT: 1};
-	static SPL_MSG_REGEX = /^([\w.]+\/[\w.]+)\:(\d+)\:(\d+)\:\s+(\w{5}\d{4}[IWE])\s+((ERROR|WARN|INFO)\:.*)$/;
+	static SPL_MSG_REGEX = /^([\w.]+(?:\/[\w.]+)?)\:(\d+)\:(\d+)\:\s+(\w{5}\d{4}[IWE])\s+((ERROR|WARN|INFO)\:.*)$/;
 	static SPL_NAMESPACE_REGEX = /^\s*(?:\bnamespace\b)\s+([a-z|A-Z|0-9|\.|\_]+)\s*\;/gm;
 	static SPL_MAIN_COMPOSITE_REGEX = /.*?(?:\bcomposite\b)(?:\s*|\/\/.*?|\/\*.*?\*\/)+([a-z|A-Z|0-9|\.|\_]+)(?:\s*|\/\/.*?|\/\*.*?\*\/)*\{/gm;
 	static STATUS_POLL_FREQUENCY = 5000;


### PR DESCRIPTION
- fix the regular expression used for compilation errors to allow for apps with no namespace, issue #31.
- open the diagnostics view automatically if any compilation errors occur.

found tangentially related issue #35 while investigating this.