### PR TITLE
Support multiple toolkit root directories

### DIFF
--- a/lib/spl-build-common.js
+++ b/lib/spl-build-common.js
@@ -91,7 +91,7 @@ export class SplBuilder {
 		// temporary build archive filename is of format
 		// .build_[fqn].zip or .build_make_[parent_dir].zip for makefile build
 		// eg: .build_sample.Vwap.zip , .build_make_Vwap.zip
-		const outputFilePath = `${appRoot}${path.sep}.build_${options.useMakefile ? "make_"+appRoot.split(path.sep).pop() : options.fqn.replace("::",".")}.zip`;
+		const outputFilePath = `${appRoot}${path.sep}.build_${options.useMakefile ? "make_"+appRoot.split(path.sep).pop() : options.fqn.replace("::",".")}_${Date.now()}.zip`;
 
 		// delete existing build archive file before creating new one
 		// TODO: handle if file is open better (windows file locks)
@@ -124,7 +124,7 @@ export class SplBuilder {
 
 			const toolkitPaths = SplBuilder.getToolkits(toolkitRootPath);
 			let tkPathString = "";
-			if (toolkitPaths) {
+			if (Array.isArray(toolkitPaths) && toolkitPaths.length > 0) {
 				const rootContents = fs.readdirSync(appRoot);
 				const newRoot = path.basename(appRoot);
 				let ignoreFiles = defaultIgnoreFiles;
@@ -859,15 +859,27 @@ export class SplBuilder {
 	 *
 	 */
 	static getToolkits(toolkitRootDir) {
-		let validToolkitPaths = null;
+		let validToolkitPaths = [];
 		if (toolkitRootDir && toolkitRootDir.trim() !==  "") {
-			if (fs.existsSync(toolkitRootDir)) {
-				let toolkitRootContents = fs.readdirSync(toolkitRootDir);
-				validToolkitPaths = toolkitRootContents
-					.filter(item => fs.lstatSync(`${toolkitRootDir}${path.sep}${item}`).isDirectory())
-					.filter(dir => fs.readdirSync(`${toolkitRootDir}${path.sep}${dir}`).filter(tkDirItem => tkDirItem === "toolkit.xml").length > 0)
-					.map(tk => ({ tk: tk, tkPath: `${toolkitRootDir}${path.sep}${tk}` }));
+			let toolkitRoots = [];
+
+			if (toolkitRootDir.includes(",") || toolkitRootDir.includes(";")) {
+				toolkitRoots.push(...toolkitRootDir.split(/[,;]/));
+			} else {
+				toolkitRoots.push(toolkitRootDir);
 			}
+			console.log("toolkitRoots:",toolkitRoots);
+
+			toolkitRoots.forEach(toolkitRoot => {
+				if (fs.existsSync(toolkitRoot)) {
+					let toolkitRootContents = fs.readdirSync(toolkitRoot);
+					validToolkitPaths.push(...toolkitRootContents
+						.filter(item => fs.lstatSync(`${toolkitRoot}${path.sep}${item}`).isDirectory())
+						.filter(dir => fs.readdirSync(`${toolkitRoot}${path.sep}${dir}`).filter(tkDirItem => tkDirItem === "toolkit.xml").length > 0)
+						.map(tk => ({ tk: tk, tkPath: `${toolkitRoot}${path.sep}${tk}` }))
+					);
+				}
+			});
 		}
 		return validToolkitPaths;
 	}

--- a/lib/spl-build-common.js
+++ b/lib/spl-build-common.js
@@ -89,8 +89,8 @@ export class SplBuilder {
 		this.messageHandler.handleInfo(`Building application archive${buildTarget}...`);
 
 		// temporary build archive filename is of format
-		// .build_[fqn].zip or .build_make_[parent_dir].zip for makefile build
-		// eg: .build_sample.Vwap.zip , .build_make_Vwap.zip
+		// .build_[fqn]_[time].zip or .build_make_[parent_dir]_[time].zip for makefile build
+		// eg: .build_sample.Vwap_1547066810853.zip , .build_make_Vwap_1547066810853.zip
 		const outputFilePath = `${appRoot}${path.sep}.build_${options.useMakefile ? "make_"+appRoot.split(path.sep).pop() : options.fqn.replace("::",".")}_${Date.now()}.zip`;
 
 		// delete existing build archive file before creating new one

--- a/lib/spl-build-common.js
+++ b/lib/spl-build-common.js
@@ -868,7 +868,6 @@ export class SplBuilder {
 			} else {
 				toolkitRoots.push(toolkitRootDir);
 			}
-			console.log("toolkitRoots:",toolkitRoots);
 
 			toolkitRoots.forEach(toolkitRoot => {
 				if (fs.existsSync(toolkitRoot)) {


### PR DESCRIPTION
- add support for build to bundle toolkits from multiple root directories. Aligns with the support that the ide-ibmstreams package has.
  - can specify something like `/home/user/toolkits,/home/user/dev/toolkits` for the *Toolkits Path* setting in the ide-ibmstreams package  and the build archive will pick up all valid toolkit subdirectories therein.
- append epoch timestamp to temporary build archive file to avoid problems when building the same application in quick succession.