### PR TITLE
cast line and column positions to numbers for compile messages

### DIFF
--- a/lib/LintHandler.js
+++ b/lib/LintHandler.js
@@ -57,7 +57,10 @@ export class LintHandler {
 					location: {
 
 						file: absolutePath,
-						position: [[parts[2]-1,parts[3]-1],[parts[2]-1,parts[3]]], // 0-indexed
+						position: [
+							[parseInt(parts[2])-1 ,parseInt(parts[3])-1],
+							[parseInt(parts[2])-1,parseInt(parts[3])]
+						], // 0-indexed
 					},
 					excerpt: parts[4],
 					description: parts[5],


### PR DESCRIPTION
compile errors in an SPL application when running Atom on Mac could periodically throw Invalid Point Exceptions. Casting all line and column numbers to int primitives prevents this from occurring.