### PR TITLE
fix toolkit version interval

### DIFF
--- a/lib/util/source-archive-utils.js
+++ b/lib/util/source-archive-utils.js
@@ -224,7 +224,7 @@ function getToolkits(toolkitCacheDir, toolkitPathSetting, appRoot) {
           }));
           const parsedDependencies = parseToolkitVersions(dependencies);
           const newestLocalToolkits = StreamsToolkitsUtils.filterNewestToolkits(allToolkits).filter(tk => tk.isLocal);
-          const toolkitsToInclude = _.intersectionWith(newestLocalToolkits, parsedDependencies, (tk, dependency) => tk.name === dependency.name && semver.satisfies(tk.version, dependency.version));
+          const toolkitsToInclude = _.intersectionWith(newestLocalToolkits, parsedDependencies, (tk, dependency) => tk.name === dependency.name && semver.satisfies(semver.coerce(tk.version), dependency.version));
           return toolkitsToInclude.map(tk => ({ name: tk.name, tkPath: path.dirname(tk.indexPath) }));
         }
       }


### PR DESCRIPTION
fixed toolkit version comparison. ex: now accepts '1.9'